### PR TITLE
ads: Use a neutral age screen

### DIFF
--- a/lib/ads/banner_ad_widget.dart
+++ b/lib/ads/banner_ad_widget.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:nes_ui/nes_ui.dart';
+import 'package:ricochlime/ads/consent_stage.dart';
 import 'package:ricochlime/utils/prefs.dart';
 
 export 'package:google_mobile_ads/google_mobile_ads.dart' show AdSize;
@@ -56,11 +57,10 @@ abstract class AdState {
   static void _startInitialize() async {
     if (_initializeStarted) return;
 
-    // We need to know the user's age to determine if we can use personalized ads.
     final age = AdState.age;
-    if (age == null) return;
-
-    if (age >= minAgeForPersonalizedAds) {
+    final correctConsentStage = Prefs.consentStage.value == ConsentStage.askForPersonalizedAds;
+    final canConsent = age != null && age >= minAgeForPersonalizedAds;
+    if (correctConsentStage && canConsent) {
       if (!kIsWeb && Platform.isIOS) {
         var status = await AppTrackingTransparency.trackingAuthorizationStatus;
         if (status == TrackingStatus.notDetermined) {
@@ -127,12 +127,12 @@ abstract class AdState {
         _ => MaxAdContentRating.ma, // mature audiences
       },
       tagForChildDirectedTreatment: switch (age) {
-        null => TagForChildDirectedTreatment.unspecified,
+        null => TagForChildDirectedTreatment.yes,
         < 13 => TagForChildDirectedTreatment.yes,
         _ => TagForChildDirectedTreatment.no,
       },
       tagForUnderAgeOfConsent: switch (age) {
-        null => TagForUnderAgeOfConsent.unspecified,
+        null => TagForUnderAgeOfConsent.yes,
         < 13 => TagForUnderAgeOfConsent.yes,
         _ => TagForUnderAgeOfConsent.no,
       },

--- a/lib/ads/banner_ad_widget.dart
+++ b/lib/ads/banner_ad_widget.dart
@@ -154,7 +154,12 @@ abstract class AdState {
 
     return BannerAd(
       adUnitId: _bannerAdUnitId,
-      request: const AdRequest(),
+      request: AdRequest(
+        nonPersonalizedAds: switch (Prefs.consentStage.value) {
+          ConsentStage.askForBirthYear => true,
+          ConsentStage.askForPersonalizedAds => null,
+        },
+      ),
       size: adSize,
       listener: BannerAdListener(
         onAdLoaded: (Ad ad) {

--- a/lib/ads/banner_ad_widget.dart
+++ b/lib/ads/banner_ad_widget.dart
@@ -75,6 +75,8 @@ abstract class AdState {
       } else {
         _checkForRequiredConsent();
       }
+    } else {
+      _checkForRequiredConsent(shouldShowConsentForm: false);
     }
 
     assert(_bannerAdUnitId.isNotEmpty);
@@ -87,7 +89,9 @@ abstract class AdState {
     Prefs.birthYear.addListener(updateRequestConfiguration);
   }
 
-  static void _checkForRequiredConsent() {
+  static void _checkForRequiredConsent({
+    bool shouldShowConsentForm = true,
+  }) {
     final params = ConsentRequestParameters();
     ConsentInformation.instance.requestConsentInfoUpdate(
       params,
@@ -95,7 +99,11 @@ abstract class AdState {
         final status = await ConsentInformation.instance.getConsentStatus();
         if (status != ConsentStatus.required) return;
         if (await ConsentInformation.instance.isConsentFormAvailable()) {
-          showConsentForm();
+          if (shouldShowConsentForm) {
+            showConsentForm();
+          } else {
+            // otherwise, the form is kept locally and can be shown later
+          }
         }
       },
       (formError) {},

--- a/lib/ads/birth_year_dialog.dart
+++ b/lib/ads/birth_year_dialog.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ricochlime/i18n/strings.g.dart';
+import 'package:ricochlime/utils/prefs.dart';
+
+class BirthYearDialog extends StatefulWidget {
+  const BirthYearDialog({
+    super.key,
+  });
+
+  @override
+  State<BirthYearDialog> createState() => _BirthYearDialogState();
+}
+
+class _BirthYearDialogState extends State<BirthYearDialog> {
+  DateTime selectedDate = DateTime.now();
+
+  @override
+  Widget build(BuildContext context) {
+    final currentYear = DateTime.now().year;
+    return AlertDialog(
+      title: Text(t.birthYear.yourBirthYear),
+      content: SizedBox(
+        width: 300,
+        height: 300,
+        child: Column(
+          children: [
+            Text(t.birthYear.reason),
+            Expanded(
+              child: StatefulBuilder(
+                builder: (context, setState) {
+                  return YearPicker(
+                    firstDate: DateTime(1900),
+                    lastDate: DateTime(currentYear),
+                    initialDate: DateTime(currentYear),
+                    selectedDate: selectedDate,
+                    onChanged: (value) {
+                      setState(() => selectedDate = value);
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            context.pop();
+          },
+          child: Text(t.common.cancel),
+        ),
+        TextButton(
+          onPressed: () {
+            Prefs.birthYear.value = selectedDate.year;
+            context.pop();
+          },
+          child: Text(t.common.ok),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ads/birth_year_dialog.dart
+++ b/lib/ads/birth_year_dialog.dart
@@ -6,7 +6,10 @@ import 'package:ricochlime/utils/prefs.dart';
 class BirthYearDialog extends StatefulWidget {
   const BirthYearDialog({
     super.key,
+    this.dismissible = true,
   });
+
+  final bool dismissible;
 
   @override
   State<BirthYearDialog> createState() => _BirthYearDialogState();
@@ -45,7 +48,7 @@ class _BirthYearDialogState extends State<BirthYearDialog> {
         ),
       ),
       actions: [
-        TextButton(
+        if (widget.dismissible) TextButton(
           onPressed: () {
             context.pop();
           },

--- a/lib/ads/consent_stage.dart
+++ b/lib/ads/consent_stage.dart
@@ -1,0 +1,20 @@
+/// Every app launch, we progress to the next consent stage.
+/// 
+/// This is to avoid spamming the user with consent dialogs.
+enum ConsentStage {
+  /// The user needs to enter their birth year.
+  askForBirthYear,
+  /// The user has entered their birth year,
+  /// but we may need to ask for consent to show personalized ads.
+  askForPersonalizedAds,
+  ;
+
+  ConsentStage get next {
+    switch (this) {
+      case ConsentStage.askForBirthYear:
+        return ConsentStage.askForPersonalizedAds;
+      case ConsentStage.askForPersonalizedAds:
+        return ConsentStage.askForPersonalizedAds;
+    }
+  }
+}

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 22
+/// Strings: 24
 ///
-/// Built on 2023-08-26 at 23:48 UTC
+/// Built on 2023-09-04 at 00:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -180,6 +180,8 @@ class _StringsSettingsPageEn {
 
 	// Translations
 	String get title => 'Settings';
+	String get birthYear => 'Your birth year';
+	String get birthYearUnknown => 'Unknown';
 	String get adConsent => 'Change ad consent';
 	String get hyperlegibleFont => 'Use the Atkinson Hyperlegible font';
 	String get appInfo => 'App info';

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 24
+/// Strings: 27
 ///
-/// Built on 2023-09-04 at 00:46 UTC
+/// Built on 2023-09-04 at 16:14 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -146,8 +146,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
 	late final _StringsHomePageEn homePage = _StringsHomePageEn._(_root);
 	late final _StringsPlayPageEn playPage = _StringsPlayPageEn._(_root);
 	late final _StringsSettingsPageEn settingsPage = _StringsSettingsPageEn._(_root);
+	late final _StringsBirthYearEn birthYear = _StringsBirthYearEn._(_root);
 	late final _StringsGameOverPageEn gameOverPage = _StringsGameOverPageEn._(_root);
 	late final _StringsTutorialPageEn tutorialPage = _StringsTutorialPageEn._(_root);
+	late final _StringsCommonEn common = _StringsCommonEn._(_root);
 }
 
 // Path: homePage
@@ -180,12 +182,22 @@ class _StringsSettingsPageEn {
 
 	// Translations
 	String get title => 'Settings';
-	String get birthYear => 'Your birth year';
-	String get birthYearUnknown => 'Unknown';
 	String get adConsent => 'Change ad consent';
 	String get hyperlegibleFont => 'Use the Atkinson Hyperlegible font';
 	String get appInfo => 'App info';
 	String licenseNotice({required Object buildYear}) => 'Ricochlime  Copyright (C) 2023-${buildYear}  Adil Hanney\nThis program comes with absolutely no warranty. This is free software, and you are welcome to redistribute it under certain conditions.';
+}
+
+// Path: birthYear
+class _StringsBirthYearEn {
+	_StringsBirthYearEn._(this._root);
+
+	final _StringsEn _root; // ignore: unused_field
+
+	// Translations
+	String get yourBirthYear => 'Your birth year';
+	String get unknown => 'Unknown';
+	String get reason => 'We need to know your birth year to make sure the ads you see are appropriate for your age.';
 }
 
 // Path: gameOverPage
@@ -222,4 +234,15 @@ class _StringsTutorialPageEn {
 	String get tapSpeedUp => 'Tap the screen to speed up your shots.';
 	String get dangerZone => 'If a slime reaches the danger zone, you\'ll lose on your next turn if you don\'t defeat it.';
 	String get moreSlimes => 'More rows of slimes will spawn each turn as you progress, so the danger zone will also get bigger.';
+}
+
+// Path: common
+class _StringsCommonEn {
+	_StringsCommonEn._(this._root);
+
+	final _StringsEn _root; // ignore: unused_field
+
+	// Translations
+	String get cancel => 'Cancel';
+	String get ok => 'Okay';
 }

--- a/lib/i18n/strings.i18n.yaml
+++ b/lib/i18n/strings.i18n.yaml
@@ -7,14 +7,16 @@ playPage:
   highScore: "Best: $p"
 settingsPage:
   title: Settings
-  birthYear: Your birth year
-  birthYearUnknown: Unknown
   adConsent: Change ad consent
   hyperlegibleFont: Use the Atkinson Hyperlegible font
   appInfo: App info
   licenseNotice: |-
     Ricochlime  Copyright (C) 2023-$buildYear  Adil Hanney
     This program comes with absolutely no warranty. This is free software, and you are welcome to redistribute it under certain conditions.
+birthYear:
+  yourBirthYear: Your birth year
+  unknown: Unknown
+  reason: We need to know your birth year to make sure the ads you see are appropriate for your age.
 gameOverPage:
   title: Game over!
   highScoreNotBeaten: You scored $p points!
@@ -29,3 +31,6 @@ tutorialPage:
   tapSpeedUp: Tap the screen to speed up your shots.
   dangerZone: If a slime reaches the danger zone, you'll lose on your next turn if you don't defeat it.
   moreSlimes: More rows of slimes will spawn each turn as you progress, so the danger zone will also get bigger.
+common:
+  cancel: Cancel
+  ok: Okay

--- a/lib/i18n/strings.i18n.yaml
+++ b/lib/i18n/strings.i18n.yaml
@@ -7,6 +7,8 @@ playPage:
   highScore: "Best: $p"
 settingsPage:
   title: Settings
+  birthYear: Your birth year
+  birthYearUnknown: Unknown
   adConsent: Change ad consent
   hyperlegibleFont: Use the Atkinson Hyperlegible font
   appInfo: App info

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,7 +50,7 @@ void _addLicenses() {
   });
 }
 
-void _handleCurrentConsentStage(BuildContext context) async {
+void handleCurrentConsentStage(BuildContext context) async {
   if (kIsWeb) return;
   if (!Platform.isAndroid && !Platform.isIOS) return;
 
@@ -79,8 +79,6 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  bool handledConsent = false;
-
   @override
   void initState() {
     super.initState();
@@ -95,15 +93,6 @@ class _MyAppState extends State<MyApp> {
 
   void _prefListener() {
     setState(() {});
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (!handledConsent) {
-      handledConsent = true;
-      _handleCurrentConsentStage(context);
-    }
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -5,6 +7,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:ricochlime/ads/banner_ad_widget.dart';
+import 'package:ricochlime/ads/birth_year_dialog.dart';
 import 'package:ricochlime/i18n/strings.g.dart';
 import 'package:ricochlime/nes/nes_theme.dart';
 import 'package:ricochlime/pages/home.dart';
@@ -26,8 +29,6 @@ void main() async {
     Prefs.birthYear.waitUntilLoaded(),
   ]);
 
-  AdState.init();
-
   runApp(TranslationProvider(child: const MyApp()));
 }
 
@@ -48,6 +49,20 @@ void _addLicenses() {
   });
 }
 
+void _handleCurrentConsentStage(BuildContext context) async {
+  if (kIsWeb) return;
+  if (!Platform.isAndroid && !Platform.isIOS) return;
+
+  if (Prefs.birthYear.value == null) {
+    await showDialog(
+      context: context,
+      builder: (context) => const BirthYearDialog(),
+    );
+  }
+
+  AdState.init();
+}
+
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
@@ -56,6 +71,8 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  bool handledConsent = false;
+
   @override
   void initState() {
     super.initState();
@@ -70,6 +87,15 @@ class _MyAppState extends State<MyApp> {
 
   void _prefListener() {
     setState(() {});
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!handledConsent) {
+      handledConsent = true;
+      _handleCurrentConsentStage(context);
+    }
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:ricochlime/ads/banner_ad_widget.dart';
 import 'package:ricochlime/ads/birth_year_dialog.dart';
+import 'package:ricochlime/ads/consent_stage.dart';
 import 'package:ricochlime/i18n/strings.g.dart';
 import 'package:ricochlime/nes/nes_theme.dart';
 import 'package:ricochlime/pages/home.dart';
@@ -54,10 +55,17 @@ void _handleCurrentConsentStage(BuildContext context) async {
   if (!Platform.isAndroid && !Platform.isIOS) return;
 
   if (Prefs.birthYear.value == null) {
+    assert(Prefs.consentStage.value == ConsentStage.askForBirthYear);
     await showDialog(
       context: context,
-      builder: (context) => const BirthYearDialog(),
+      barrierDismissible: false,
+      builder: (context) => const BirthYearDialog(
+        dismissible: false,
+      ),
     );
+    assert(Prefs.birthYear.value != null);
+  } else if (Prefs.consentStage.value == ConsentStage.askForBirthYear) {
+    Prefs.consentStage.value = Prefs.consentStage.value.next;
   }
 
   AdState.init();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,11 +18,15 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   LocaleSettings.useDeviceLocale();
   Prefs.init();
-  AdState.init();
   _addLicenses();
   GoogleFonts.config.allowRuntimeFetching = false;
 
-  await Prefs.highScore.waitUntilLoaded();
+  await Future.wait([
+    Prefs.highScore.waitUntilLoaded(),
+    Prefs.birthYear.waitUntilLoaded(),
+  ]);
+
+  AdState.init();
 
   runApp(TranslationProvider(child: const MyApp()));
 }

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:nes_ui/nes_ui.dart';
 import 'package:ricochlime/i18n/strings.g.dart';
+import 'package:ricochlime/main.dart';
 import 'package:ricochlime/pages/play.dart';
 import 'package:ricochlime/pages/settings.dart';
 import 'package:ricochlime/pages/tutorial.dart';
@@ -11,8 +12,17 @@ import 'package:ricochlime/utils/brightness_extension.dart';
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
+  static bool handledConsent = false;
+
   @override
   Widget build(BuildContext context) {
+    if (!handledConsent) {
+      handledConsent = true;
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        handleCurrentConsentStage(context);
+      });
+    }
+
     final colorScheme = Theme.of(context).colorScheme;
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:collapsible/collapsible.dart';
 import 'package:flutter/material.dart';
 import 'package:ricochlime/ads/banner_ad_widget.dart';
 import 'package:ricochlime/i18n/strings.g.dart';
@@ -20,13 +21,44 @@ class SettingsPage extends StatelessWidget {
       body: ListView(
         children: [
           // ad consent
-          if (AdState.adsSupported)
+          if (AdState.adsSupported) ...[
             ListTile(
               onTap: () {
-                AdState.showConsentForm();
+                // TODO(adil192): show dialog to select birth year
               },
-              title: Text(t.settingsPage.adConsent),
+              title: Text(t.settingsPage.birthYear),
+              trailing: ValueListenableBuilder(
+                valueListenable: Prefs.birthYear,
+                builder: (context, birthYear, child) {
+                  return Text(
+                    switch (birthYear) {
+                      null => t.settingsPage.birthYearUnknown,
+                      _ => '$birthYear',
+                    },
+                  );
+                },
+              ),
             ),
+
+            ValueListenableBuilder(
+              valueListenable: Prefs.birthYear,
+              builder: (context, birthYear, child) {
+                final age = AdState.age;
+                final collapsed = age == null || age < AdState.minAgeForPersonalizedAds;
+                return Collapsible(
+                  collapsed: collapsed,
+                  axis: CollapsibleAxis.vertical,
+                  child: child!,
+                );
+              },
+              child: ListTile(
+                onTap: () {
+                  AdState.showConsentForm();
+                  },
+                title: Text(t.settingsPage.adConsent),
+              ),
+            ),
+          ],
 
           // Hyperlegible font
           ValueListenableBuilder(

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:collapsible/collapsible.dart';
 import 'package:flutter/material.dart';
 import 'package:ricochlime/ads/banner_ad_widget.dart';
+import 'package:ricochlime/ads/birth_year_dialog.dart';
 import 'package:ricochlime/i18n/strings.g.dart';
 import 'package:ricochlime/utils/prefs.dart';
 import 'package:ricochlime/utils/version.dart';
@@ -24,15 +25,18 @@ class SettingsPage extends StatelessWidget {
           if (AdState.adsSupported) ...[
             ListTile(
               onTap: () {
-                // TODO(adil192): show dialog to select birth year
+                showDialog(
+                  context: context,
+                  builder: (context) => const BirthYearDialog(),
+                );
               },
-              title: Text(t.settingsPage.birthYear),
+              title: Text(t.birthYear.yourBirthYear),
               trailing: ValueListenableBuilder(
                 valueListenable: Prefs.birthYear,
                 builder: (context, birthYear, child) {
                   return Text(
                     switch (birthYear) {
-                      null => t.settingsPage.birthYearUnknown,
+                      null => t.birthYear.unknown,
                       _ => '$birthYear',
                     },
                   );

--- a/lib/utils/prefs.dart
+++ b/lib/utils/prefs.dart
@@ -24,11 +24,15 @@ abstract class Prefs {
 
   static late final PlainPref<bool> hyperlegibleFont;
 
+  static late final PlainPref<int?> birthYear;
+
   static void init() {
     currentGame = PlainPref('currentGame', null);
     highScore = PlainPref('highScore', 0);
 
     hyperlegibleFont = PlainPref('hyperlegibleFont', false);
+
+    birthYear = PlainPref('birthYear', null);
   }
 }
 
@@ -118,6 +122,7 @@ class PlainPref<T> extends IPref<T> {
     super.deprecatedKeys,
   }): assert(
     T == bool || T == int || T == double || T == String
+      || T == typeOf<int?>()
       || T == typeOf<Uint8List?>()
       || T == typeOf<List<String>>() || T == typeOf<Set<String>>()
       || T == typeOf<Queue<String>>()
@@ -162,8 +167,12 @@ class PlainPref<T> extends IPref<T> {
 
       if (T == bool) {
         return await _prefs!.setBool(key, value as bool);
-      } else if (T == int) {
-        return await _prefs!.setInt(key, value as int);
+      } else if (T == int || T == typeOf<int?>()) {
+        if (value == null) {
+          return await _prefs!.remove(key);
+        } else {
+          return await _prefs!.setInt(key, value as int);
+        }
       } else if (T == double) {
         return await _prefs!.setDouble(key, value as double);
       } else if (T == typeOf<Uint8List?>()) {

--- a/lib/utils/prefs.dart
+++ b/lib/utils/prefs.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:ricochlime/ads/consent_stage.dart';
 import 'package:ricochlime/flame/game_data.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -25,6 +26,7 @@ abstract class Prefs {
   static late final PlainPref<bool> hyperlegibleFont;
 
   static late final PlainPref<int?> birthYear;
+  static late final PlainPref<ConsentStage> consentStage;
 
   static void init() {
     currentGame = PlainPref('currentGame', null);
@@ -33,6 +35,7 @@ abstract class Prefs {
     hyperlegibleFont = PlainPref('hyperlegibleFont', false);
 
     birthYear = PlainPref('birthYear', null);
+    consentStage = PlainPref('consentStage', ConsentStage.values.first);
   }
 }
 
@@ -128,6 +131,7 @@ class PlainPref<T> extends IPref<T> {
       || T == typeOf<Queue<String>>()
       || T == AxisDirection || T == ThemeMode || T == TargetPlatform
       || T == typeOf<GameData?>()
+      || T == ConsentStage
   );
 
   @override
@@ -197,6 +201,8 @@ class PlainPref<T> extends IPref<T> {
       } else if (T == typeOf<GameData?>()) {
         final json = jsonEncode(value);
         return await _prefs!.setString(key, json);
+      } else if (T == ConsentStage) {
+        return await _prefs!.setInt(key, (value as ConsentStage).index);
       } else {
         return await _prefs!.setString(key, value as String);
       }
@@ -238,6 +244,9 @@ class PlainPref<T> extends IPref<T> {
         final decoded = jsonDecode(json) as Map<String, dynamic>?;
         if (decoded == null) return null;
         return GameData.fromJson(decoded) as T;
+      } else if (T == ConsentStage) {
+        final index = _prefs!.getInt(key);
+        return index != null ? ConsentStage.values[index] as T? : null;
       } else {
         return _prefs!.get(key) as T?;
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  collapsible:
+    dependency: "direct main"
+    description:
+      name: collapsible
+      sha256: d57126aba739f918562dd9e2ce8435cbfc446d52cf02befcaf22f75c01824ee8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   collection:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,8 @@ dependencies:
 
   nes_ui: ^0.7.0
 
+  collapsible: ^1.0.0
+
 dev_dependencies:
   flutter_lints: ^2.0.2
 


### PR DESCRIPTION
Resolves #12 

## Tasks
- [x] Ask user for their age/birthyear on first launch
- [x] Only ask for ad consent on second launch
- [x] Delay ad initialisation until we know the user's age
- [x] Pass underage flag to google_mobile_ads
- [x] Allow user to change their birthyear in settings
