### PR TITLE
ci: publish pubspec-fdroid.lock

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -102,20 +102,38 @@ jobs:
 
       - name: Build aab
         if: ${{ matrix.foss == false }}
-        run: flutter build appbundle
-
-      - name: Rename aab
-        if: ${{ matrix.foss == false }}
         run: |
+          flutter build appbundle
           mkdir -p output
           mv build/app/outputs/bundle/release/app-release.aab output/Ricochlime.aab
-
       - name: Upload aab artifact
         if: ${{ matrix.foss == false }}
         uses: actions/upload-artifact@v7
         with:
           name: Ricochlime-Android-PlayStore
           path: output/Ricochlime.aab
+
+      - name: Produce pubspec-fdroid.lock
+        if: ${{ matrix.foss == true }}
+        run: |
+          cp pubspec.lock pubspec-fdroid.lock
+          if grep -q in_app_purchase pubspec.lock; then
+            echo "FOSS patch not applied?"
+            exit 1
+          fi
+      - name: Upload pubspec-fdroid.lock artifact
+        if: ${{ matrix.foss == true }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: pubspec-fdroid.lock
+          path: pubspec-fdroid.lock
+          archive: false
+      - name: Upload pubspec-fdroid.lock to GitHub release
+        uses: svenstaro/upload-release-action@v2
+        if: ${{ matrix.foss == true && startsWith(github.ref, 'refs/tags/') }}
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: pubspec-fdroid.lock
 
   upload-to-play-store:
     name: Upload to Play Store


### PR DESCRIPTION
To allow F-Droid builds to use the `--enforce-lockfile` flag.

Hopefully resolves #88 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `pubspec-fdroid.lock` from CI so F-Droid builds can use `--enforce-lockfile`. Also adds a safety check for the FOSS variant and uploads the lockfile to artifacts and tagged releases.

- **New Features**
  - Generate `pubspec-fdroid.lock` for FOSS builds by copying `pubspec.lock`.
  - Fail if `in_app_purchase` is present to ensure the FOSS patch is applied.
  - Upload the lockfile as an artifact and to tagged releases via `actions/upload-artifact@v7` and `svenstaro/upload-release-action@v2`.

- **Refactors**
  - Combine Play Store AAB build and rename into one step.

"Note: Saber is trialling Cubic AI code review. AI output may contain mistakes, misconceptions, and hallucinations. You can act on the AI feedback if you find it helpful; otherwise you can disregard it and wait for a human reviewer."

<sup>Written for commit c85173213f6028af3c5e003d637da70da5fbec2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

